### PR TITLE
Update to the latest spec version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,11 @@ A Python implementation of the [mustache templating language](http://mustache.gi
 
 This library is a fork of [chevron](https://github.com/noahmorrison/chevron) authored by [Noah Morrison](https://github.com/noahmorrison).
 
-At this time, the only changes are switching to a modern build system, dropping support for Python 2, and verifying support for Python 3.7+.
+The following changes have been made:
+
+- Switched to a modern build system (`poetry`)
+- Switched to GitHub Actions for CI
+- Used Ruff for linting and formatting
+- Dropped support for Python 2
+- Verified support for Python 3.7 - 3.12
+- Fixed bug where variables could be incorrectly resolved from other scopes (see [#3](https://github.com/zanieb/chevron-blue/pull/3))

--- a/src/chevron_blue/renderer.py
+++ b/src/chevron_blue/renderer.py
@@ -36,9 +36,10 @@ def _get_key(key, scopes, warn, keep, def_ldel, def_rdel):
 
     # Loop through the scopes
     for scope in scopes:
+        key_index = 0
         try:
             # For every dot seperated key
-            for child in key.split("."):
+            for key_index, child in enumerate(key.split(".")):
                 # Move into the scope
                 try:
                     # Try subscripting (Normal dictionaries)
@@ -64,8 +65,11 @@ def _get_key(key, scopes, warn, keep, def_ldel, def_rdel):
                 return scope or ""
         except (AttributeError, KeyError, IndexError, ValueError):
             # We couldn't find the key in the current scope
-            # We'll try again on the next pass
-            pass
+            # We'll try again on the next pass if this is the first key
+            # Otherwise, we should not continue up the stack
+            # ref https://github.com/mustache/spec/pull/48#issuecomment-5919586
+            if key_index > 0:
+                break
 
     # We couldn't find the key in any of the scopes
 

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -31,7 +31,7 @@ def _test_case_from_path(json_path):
                     obj["template"], obj["data"], partials_dict=obj.get("partials", {})
                 )
 
-                self.assertEqual(result, obj["expected"])
+                assert result == obj["expected"], obj["desc"]
 
             test_case.__doc__ = "suite: {0}    desc: {1}".format(spec, obj["desc"])
             return test_case
@@ -41,7 +41,12 @@ def _test_case_from_path(json_path):
 
         # Generates a unit test for each test object
         for i, test in enumerate(yaml["tests"]):
-            vars()["test_" + str(i)] = _test_from_object(test)
+            vars()[
+                "test_" + test["name"].lower().replace(" ", "_").replace("-", "_")
+            ] = _test_from_object(test)
+
+        def __repr__(self) -> str:
+            return f"<GeneratedMustacheTestCase json_path={json_path}>"
 
     # Return the built class
     return MustacheTestCase


### PR DESCRIPTION
One test case was failing where when a variable key was missing, the renderer would always look in additional scopes. However, the renderer should only look in additional scopes when the _first_ member of a key is missing — subsequent missing keys should be treated as falsey. See https://github.com/mustache/spec/pull/48#issuecomment-5919586