### PR TITLE
Fix bug where `no_escape` was not passed to recursive `render` calls

### DIFF
--- a/src/chevron_blue/renderer.py
+++ b/src/chevron_blue/renderer.py
@@ -301,6 +301,7 @@ def render(
                         scopes=data and [data] + scopes or scopes,
                         warn=warn,
                         keep=keep,
+                        no_escape=no_escape,
                     ),
                 )
 
@@ -340,6 +341,7 @@ def render(
                         def_rdel=def_rdel,
                         warn=warn,
                         keep=keep,
+                        no_escape=no_escape,
                     )
                     output += rend
 
@@ -378,6 +380,7 @@ def render(
                 scopes=scopes,
                 warn=warn,
                 keep=keep,
+                no_escape=no_escape,
             )
 
             # If the partial was indented

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -525,6 +525,20 @@ class ExpandedCoverage(unittest.TestCase):
         expected = '< > & "'
         self.assertEqual(result, expected)
 
+        args = {
+            "template": "{{#a}}{{ html_escaped }}{{/a}}",
+            "data": {
+                "a": {
+                    "html_escaped": '< > & "',
+                }
+            },
+            "no_escape": True,
+        }
+
+        result = chevron_blue.render(**args)
+        expected = '< > & "'
+        self.assertEqual(result, expected)
+
 
 # Run unit tests from command line
 if __name__ == "__main__":


### PR DESCRIPTION
Bug in #4 