### PR TITLE
Implement spec-compliant lambdas

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ The following changes have been made:
 - Verified support for Python 3.7 - 3.12
 - Fixed bug where variables could be incorrectly resolved from other scopes (see [#3](https://github.com/zanieb/chevron-blue/pull/3))
 - Added global `--no-escape` option to disable HTML escaping (see [#4](https://github.com/zanieb/chevron-blue/pull/4))
+- Implemented variable lambdas and single-argument section lambdas.

--- a/src/chevron_blue/renderer.py
+++ b/src/chevron_blue/renderer.py
@@ -1,3 +1,4 @@
+import inspect
 import io
 import sys
 from collections.abc import Callable, Iterator, Sequence
@@ -180,7 +181,6 @@ def render(
 
     A string containing the rendered template.
     """
-
     # If the template is a seqeuence but not derived from a string
     if isinstance(template, Sequence) and not isinstance(template, str):
         # Then we don't need to tokenize it
@@ -194,6 +194,12 @@ def render(
             tokens = tokenize(template, def_ldel, def_rdel)
 
     output = ""
+
+    # Keep track of the original delimiters.
+    # Partials and variable lambdas want the originals.
+    # Section lambdas want the current delimiters.
+    orig_ldel = def_ldel
+    orig_rdel = def_rdel
 
     if scopes is None:
         scopes = [data]
@@ -231,6 +237,23 @@ def render(
                 # (inverted tags do this)
                 # then get the un-coerced object (next in the stack)
                 thing = scopes[1]
+            if isinstance(thing, Callable):
+                # Handle the variable lambda according to
+                # https://jgonggrijp.gitlab.io/wontache/mustache.5.html#Variables
+                thing = render(
+                    template=str(thing()),
+                    data=data,
+                    partials_path=partials_path,
+                    partials_ext=partials_ext,
+                    partials_dict=partials_dict,
+                    padding=padding,
+                    def_ldel=orig_ldel,
+                    def_rdel=orig_rdel,
+                    scopes=scopes,
+                    warn=warn,
+                    keep=keep,
+                    no_escape=True,
+                )
             if not isinstance(thing, str):
                 thing = str(thing)
             output += thing if no_escape else _html_escape(thing)
@@ -241,6 +264,21 @@ def render(
             thing = _get_key(
                 key, scopes, warn=warn, keep=keep, def_ldel=def_ldel, def_rdel=def_rdel
             )
+            if isinstance(thing, Callable):
+                thing = render(
+                    template=str(thing()),
+                    data=data,
+                    partials_path=partials_path,
+                    partials_ext=partials_ext,
+                    partials_dict=partials_dict,
+                    padding=padding,
+                    def_ldel=orig_ldel,
+                    def_rdel=orig_rdel,
+                    scopes=scopes,
+                    warn=warn,
+                    keep=keep,
+                    no_escape=True,
+                )
             if not isinstance(thing, str):
                 thing = str(thing)
             output += thing
@@ -269,7 +307,7 @@ def render(
                     elif tag_type == "no escape":
                         text += "%s& %s %s" % (def_ldel, tag_key, def_rdel)
                     else:
-                        text += "%s%s %s%s" % (
+                        text += "%s%s%s%s" % (
                             def_ldel,
                             {
                                 "commment": "!",
@@ -287,10 +325,20 @@ def render(
 
                 g_token_cache[text] = tags
 
-                rend = scope(
-                    text,
-                    lambda template, data=None: render(
-                        template,
+                # Choose whether to do the "standard" way or the chevron's way based off the number of args
+                sig = inspect.signature(scope)
+                count_params = len(
+                    [
+                        param
+                        for param in sig.parameters.values()
+                        if param.default is inspect.Parameter.empty
+                    ]
+                )
+                if count_params == 1:
+                    # The standard way.
+                    # Documented in https://jgonggrijp.gitlab.io/wontache/mustache.5.html#Sections
+                    rend = render(
+                        scope(text),
                         data={},
                         partials_path=partials_path,
                         partials_ext=partials_ext,
@@ -302,8 +350,26 @@ def render(
                         warn=warn,
                         keep=keep,
                         no_escape=no_escape,
-                    ),
-                )
+                    )
+                else:
+                    # Nonstandard (but useful!)
+                    rend = scope(
+                        text,
+                        lambda template, data=None: render(
+                            template,
+                            data={},
+                            partials_path=partials_path,
+                            partials_ext=partials_ext,
+                            partials_dict=partials_dict,
+                            padding=padding,
+                            def_ldel=def_ldel,
+                            def_rdel=def_rdel,
+                            scopes=data and [data] + scopes or scopes,
+                            warn=warn,
+                            keep=keep,
+                            no_escape=no_escape,
+                        ),
+                    )
 
                 output += rend
 
@@ -374,8 +440,8 @@ def render(
                 partials_path=partials_path,
                 partials_ext=partials_ext,
                 partials_dict=partials_dict,
-                def_ldel=def_ldel,
-                def_rdel=def_rdel,
+                def_ldel=orig_ldel,
+                def_rdel=orig_rdel,
                 padding=part_padding,
                 scopes=scopes,
                 warn=warn,
@@ -390,5 +456,7 @@ def render(
 
             # Add the partials output to the ouput
             output += part_out
+        elif tag == "set delimiter":
+            def_ldel, def_rdel = key.split()
 
     return output


### PR DESCRIPTION
Chevron has lambdas, but they don't follow the spec (and they're completely missing for variables.)

This commit activates the lambda spec tests and makes them pass (and adds a test for a corner case not covered by the spec.)